### PR TITLE
VEI-148: Add a new field to the VatCustomerInfo class

### DIFF
--- a/app/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfo.scala
+++ b/app/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfo.scala
@@ -73,7 +73,7 @@ object VatCustomerInfo {
         (__ \ "approvedInformation" \ "customerDetails" \ "individual" \ "middleName").readNullable[String] and
         (__ \ "approvedInformation" \ "customerDetails" \ "individual" \ "lastName").readNullable[String] and
         (__ \ "approvedInformation" \ "customerDetails" \ "singleMarketIndicator").read[Boolean] and
-        (__ \ "approvedInformation" \ "customerDetails" \ "deregistrationDecisionDate").readNullable[LocalDate]
+        (__ \ "approvedInformation" \ "deregistration" \ "effectDateOfCancellation").readNullable[LocalDate]
       )(VatCustomerInfo.fromDesPayload _)
 
   implicit val writes: OWrites[VatCustomerInfo] =

--- a/app/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfo.scala
+++ b/app/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfo.scala
@@ -27,7 +27,8 @@ case class VatCustomerInfo(
                             registrationDate: Option[LocalDate],
                             organisationName: Option[String],
                             individualName: Option[String],
-                            singleMarketIndicator: Boolean
+                            singleMarketIndicator: Boolean,
+                            deregistrationDecisionDate: Option[LocalDate]
                           )
 
 object VatCustomerInfo {
@@ -40,7 +41,8 @@ object VatCustomerInfo {
                               individualFirstName: Option[String],
                               individualMiddleName: Option[String],
                               individualLastName: Option[String],
-                              singleMarketIndicator: Boolean
+                              singleMarketIndicator: Boolean,
+                              deregistrationDecisionDate: Option[LocalDate]
                             ): VatCustomerInfo = {
 
     val firstName = individualFirstName.fold("")(fn => s"$fn ")
@@ -56,7 +58,8 @@ object VatCustomerInfo {
       } else {
         Some(s"$firstName$middleName$lastName")
       },
-      singleMarketIndicator = singleMarketIndicator
+      singleMarketIndicator = singleMarketIndicator,
+      deregistrationDecisionDate = deregistrationDecisionDate
     )
   }
 
@@ -69,7 +72,8 @@ object VatCustomerInfo {
         (__ \ "approvedInformation" \ "customerDetails" \ "individual" \ "firstName").readNullable[String] and
         (__ \ "approvedInformation" \ "customerDetails" \ "individual" \ "middleName").readNullable[String] and
         (__ \ "approvedInformation" \ "customerDetails" \ "individual" \ "lastName").readNullable[String] and
-        (__ \ "approvedInformation" \ "customerDetails" \ "singleMarketIndicator").read[Boolean]
+        (__ \ "approvedInformation" \ "customerDetails" \ "singleMarketIndicator").read[Boolean] and
+        (__ \ "approvedInformation" \ "customerDetails" \ "deregistrationDecisionDate").readNullable[LocalDate]
       )(VatCustomerInfo.fromDesPayload _)
 
   implicit val writes: OWrites[VatCustomerInfo] =

--- a/test/uk/gov/hmrc/iossintermediaryregistration/base/BaseSpec.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/base/BaseSpec.scala
@@ -62,7 +62,8 @@ trait BaseSpec
       desAddress = DesAddress("Line 1", None, None, None, None, Some("AA11 1AA"), "GB"),
       organisationName = Some("Company name"),
       singleMarketIndicator = true,
-      individualName = None
+      individualName = None,
+      deregistrationDecisionDate = None
     )
 
   val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")

--- a/test/uk/gov/hmrc/iossintermediaryregistration/connectors/GetVatInfoConnectorSpec.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/connectors/GetVatInfoConnectorSpec.scala
@@ -72,7 +72,8 @@ class GetVatInfoConnectorSpec extends BaseSpec with WireMockHelper {
           desAddress = DesAddress("line 1", Some("line 2"), None, None, None, Some("AA11 1AA"), "GB"),
           organisationName = Some("Foo"),
           singleMarketIndicator = false,
-          individualName = None
+          individualName = None,
+          deregistrationDecisionDate = None
         )
 
         result `mustBe` Right(expectedResult)

--- a/test/uk/gov/hmrc/iossintermediaryregistration/controllers/VatInfoControllerSpec.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/controllers/VatInfoControllerSpec.scala
@@ -29,7 +29,8 @@ class VatInfoControllerSpec extends BaseSpec {
         desAddress = DesAddress("line1", None, None, None, None, Some("AA11 1AA"), "GB"),
         organisationName = Some("Foo"),
         singleMarketIndicator = false,
-        individualName = None
+        individualName = None,
+        deregistrationDecisionDate = None
       )
 
       when(mockConnector.getVatCustomerDetails(any())(any())) thenReturn Right(vatInfo).toFuture

--- a/test/uk/gov/hmrc/iossintermediaryregistration/generators/Generators.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/generators/Generators.scala
@@ -84,6 +84,7 @@ trait Generators {
         organisationName <- arbitrary[String]
         individualName <- arbitrary[String]
         singleMarketIndicator <- arbitrary[Boolean]
+        deregistrationDecisionDate <- arbitrary[LocalDate]
       }
       yield
         VatCustomerInfo(
@@ -91,7 +92,8 @@ trait Generators {
           registrationDate = Some(registrationDate),
           organisationName = Some(organisationName),
           individualName = Some(individualName),
-          singleMarketIndicator = singleMarketIndicator
+          singleMarketIndicator = singleMarketIndicator,
+          deregistrationDecisionDate = Some(deregistrationDecisionDate)
         )
     }
   }

--- a/test/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfoSpec.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfoSpec.scala
@@ -36,7 +36,8 @@ class VatCustomerInfoSpec extends BaseSpec {
                 "middleName" -> "B",
                 "lastName" -> "C"
               ),
-              "singleMarketIndicator" -> false
+              "singleMarketIndicator" -> false,
+              "deregistrationDecisionDate" -> "2021-01-02"
             )
           )
         )
@@ -46,7 +47,8 @@ class VatCustomerInfoSpec extends BaseSpec {
           registrationDate = Some(LocalDate.of(2020, 1, 2)),
           organisationName = Some("Foo"),
           singleMarketIndicator = false,
-          individualName = Some("A B C")
+          individualName = Some("A B C"),
+          deregistrationDecisionDate = Some(LocalDate.of(2021, 1, 2))
         )
 
         json.validate[VatCustomerInfo](VatCustomerInfo.desReads) mustBe JsSuccess(expectedResult)
@@ -73,7 +75,8 @@ class VatCustomerInfoSpec extends BaseSpec {
           registrationDate = None,
           organisationName = None,
           singleMarketIndicator = false,
-          individualName = None
+          individualName = None,
+          deregistrationDecisionDate = None
         )
 
         json.validate[VatCustomerInfo](VatCustomerInfo.desReads) mustBe JsSuccess(expectedResult)

--- a/test/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfoSpec.scala
+++ b/test/uk/gov/hmrc/iossintermediaryregistration/models/des/VatCustomerInfoSpec.scala
@@ -36,8 +36,10 @@ class VatCustomerInfoSpec extends BaseSpec {
                 "middleName" -> "B",
                 "lastName" -> "C"
               ),
-              "singleMarketIndicator" -> false,
-              "deregistrationDecisionDate" -> "2021-01-02"
+              "singleMarketIndicator" -> false
+            ),
+            "deregistration" -> Json.obj(
+              "effectDateOfCancellation" -> "2021-01-02"
             )
           )
         )


### PR DESCRIPTION
This PR includes changes required to support the front-end updates introduced in this [PR](https://github.com/hmrc/ioss-intermediary-registration-frontend/pull/20).